### PR TITLE
Fix JVM profiling for non-root users

### DIFF
--- a/cli/cmd/kubernetes/job/jvm.go
+++ b/cli/cmd/kubernetes/job/jvm.go
@@ -70,6 +70,9 @@ func (c *jvmCreator) create(targetPod *v1.Pod, targetDetails *data.TargetDetails
 									MountPath: "/var/lib/docker",
 								},
 							},
+							SecurityContext: &v1.SecurityContext{
+								Privileged: boolPtr(true),
+							},
 						},
 					},
 					RestartPolicy: "Never",


### PR DESCRIPTION
Finding target processes was failing on containers that used non-root users.