### PR TITLE
read logs from container

### DIFF
--- a/cli/cmd/kubernetes/job/bpf.go
+++ b/cli/cmd/kubernetes/job/bpf.go
@@ -72,7 +72,7 @@ func (b *bpfCreator) create(targetPod *apiv1.Pod, targetDetails *data.TargetDeta
 					Containers: []apiv1.Container{
 						{
 							ImagePullPolicy: apiv1.PullAlways,
-							Name:            "kubectl-flame",
+							Name:            ContainerName,
 							Image:           imageName,
 							Command:         []string{"/app/agent"},
 							Args: []string{id,

--- a/cli/cmd/kubernetes/job/jvm.go
+++ b/cli/cmd/kubernetes/job/jvm.go
@@ -66,7 +66,7 @@ func (c *jvmCreator) create(targetPod *apiv1.Pod, targetDetails *data.TargetDeta
 					Containers: []apiv1.Container{
 						{
 							ImagePullPolicy: apiv1.PullAlways,
-							Name:            "kubectl-flame",
+							Name:            ContainerName,
 							Image:           imageName,
 							Command:         []string{"/app/agent"},
 							Args:            args,

--- a/cli/cmd/kubernetes/job/root.go
+++ b/cli/cmd/kubernetes/job/root.go
@@ -10,7 +10,10 @@ import (
 	"github.com/VerizonMedia/kubectl-flame/cli/cmd/data"
 )
 
-const baseImageName = "verizondigital/kubectl-flame"
+const (
+	baseImageName = "verizondigital/kubectl-flame"
+	ContainerName = "kubectl-flame"
+)
 
 var (
 	jvm = jvmCreator{}

--- a/cli/cmd/kubernetes/read.go
+++ b/cli/cmd/kubernetes/read.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/VerizonMedia/kubectl-flame/cli/cmd/kubernetes/job"
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -74,10 +75,11 @@ func WaitForPodStart(target *data.TargetDetails, ctx context.Context) (*apiv1.Po
 func GetLogsFromPod(pod *apiv1.Pod, handler DataHandler, ctx context.Context) (chan bool, error) {
 	done := make(chan bool)
 	req := clientSet.CoreV1().
-		Pods(pod.Namespace).
-		GetLogs(pod.Name, &apiv1.PodLogOptions{
-			Follow: true,
-		})
+    		Pods(pod.Namespace).
+    		GetLogs(pod.Name, &apiv1.PodLogOptions{
+    			Follow:    true,
+    			Container: job.ContainerName,
+    		})
 
 	readCloser, err := req.Stream(ctx)
 	if err != nil {


### PR DESCRIPTION
this pr makes kubectl-flame work in envs where sidecar container is injected (for example: service mesh)
