### PR TITLE
Allow to speficy profiling event (alloc, cpu, itimer etc.)

### DIFF
--- a/agent/details/profiling_job.go
+++ b/agent/details/profiling_job.go
@@ -15,4 +15,5 @@ type ProfilingJob struct {
 	PodUID            string
 	Language          api.ProgrammingLanguage
 	TargetProcessName string
+	Event             api.ProfilingEvent
 }

--- a/agent/main.go
+++ b/agent/main.go
@@ -39,8 +39,8 @@ func main() {
 }
 
 func validateArgs() (*details.ProfilingJob, error) {
-	if len(os.Args) != 7 && len(os.Args) != 8 {
-		return nil, errors.New("expected 6 or 7 arguments")
+	if len(os.Args) != 8 && len(os.Args) != 9 {
+		return nil, errors.New("expected 7 or 8 arguments")
 	}
 
 	duration, err := time.ParseDuration(os.Args[5])
@@ -55,8 +55,9 @@ func validateArgs() (*details.ProfilingJob, error) {
 	currentJob.ContainerID = strings.Replace(os.Args[4], "docker://", "", 1)
 	currentJob.Duration = duration
 	currentJob.Language = api.ProgrammingLanguage(os.Args[6])
-	if len(os.Args) == 8 {
-		currentJob.TargetProcessName = os.Args[7]
+	currentJob.Event = api.ProfilingEvent(os.Args[7])
+	if len(os.Args) == 9 {
+		currentJob.TargetProcessName = os.Args[8]
 	}
 
 	return currentJob, nil

--- a/agent/profiler/jvm.go
+++ b/agent/profiler/jvm.go
@@ -44,7 +44,8 @@ func (j *JvmProfiler) Invoke(job *details.ProfilingJob) error {
 	}
 
 	duration := strconv.Itoa(int(job.Duration.Seconds()))
-	cmd := exec.Command(profilerSh, "-d", duration, "-f", fileName, "-e", "wall", pid)
+	event := string(job.Event)
+	cmd := exec.Command(profilerSh, "-d", duration, "-f", fileName, "-e", event, pid)
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out

--- a/api/profiling_events.go
+++ b/api/profiling_events.go
@@ -1,0 +1,33 @@
+package api
+
+type ProfilingEvent string
+
+const (
+	Cpu         ProfilingEvent = "cpu"
+	Alloc       ProfilingEvent = "alloc"
+	Lock        ProfilingEvent = "lock"
+	CacheMisses ProfilingEvent = "cache-misses"
+	Wall        ProfilingEvent = "wall"
+	Itimer      ProfilingEvent = "itimer"
+)
+
+var (
+	supportedEvents = []ProfilingEvent{Cpu, Alloc, Lock, CacheMisses, Wall, Itimer}
+)
+
+func AvailableEvents() []ProfilingEvent {
+	return supportedEvents
+}
+
+func IsSupportedEvent(event string) bool {
+	return containsEvent(ProfilingEvent(event), AvailableEvents())
+}
+
+func containsEvent(e ProfilingEvent, events []ProfilingEvent) bool {
+	for _, current := range events {
+		if e == current {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/cmd/data/target.go
+++ b/cli/cmd/data/target.go
@@ -12,6 +12,7 @@ type TargetDetails struct {
 	PodName       string
 	ContainerName string
 	ContainerId   string
+	Event	      api.ProfilingEvent
 	Duration      time.Duration
 	Id            string
 	FileName      string

--- a/cli/cmd/kubernetes/job/jvm.go
+++ b/cli/cmd/kubernetes/job/jvm.go
@@ -21,7 +21,8 @@ func (c *jvmCreator) create(targetPod *apiv1.Pod, targetDetails *data.TargetDeta
 	imageName := c.getAgentImage(targetDetails)
 	args := []string{id, string(targetPod.UID),
 		targetDetails.ContainerName, targetDetails.ContainerId,
-		targetDetails.Duration.String(), string(targetDetails.Language)}
+		targetDetails.Duration.String(), string(targetDetails.Language),
+		string(targetDetails.Event)}
 
 	if targetDetails.Pgrep != "" {
 		args = append(args, targetDetails.Pgrep)


### PR DESCRIPTION
Adds the option to choose a different profiling event, by specifying it with `-e`. As before `wall` is the default event for the async-profiler. In case a mode is chosen which is not supported in the given container, this yields an empty flame graph. The alloc event requires the openjdk-dbg package to be installed in the container for example.  

Closes #30 