### PR TITLE
Use python base image and fix pip py-spy installation issue

### DIFF
--- a/agent/docker/python/Dockerfile
+++ b/agent/docker/python/Dockerfile
@@ -4,14 +4,16 @@ ADD . /go/src/github.com/VerizonMedia/kubectl-flame
 RUN go get -d -v ./...
 RUN cd agent && go build -o /go/bin/agent
 
-FROM alpine AS pyspybuild
-RUN apk add python3 py3-pip
-RUN echo 'manylinux1_compatible = True' > /usr/lib/python3.8/site-packages/_manylinux.py
+FROM python:3.8-alpine AS pyspybuild
+# only works with pip version 20.2.4
+# https://github.com/benfred/py-spy/issues/353
+RUN pip install pip==20.2.4
+RUN echo 'manylinux1_compatible = True' > /usr/local/lib/python3.8/site-packages/_manylinux.py
 RUN pip3 install py-spy==0.4.0.dev1
 
-FROM alpine
+FROM python:3.8-alpine
 RUN mkdir /app
 COPY --from=agentbuild /go/bin/agent /app/agent
-COPY --from=pyspybuild /usr/bin/py-spy /app/py-spy
+COPY --from=pyspybuild /usr/local/bin/py-spy /app/py-spy
 
 CMD [ "/app/agent" ]


### PR DESCRIPTION
## Description
It Fixes the python image build `py-spy` installation. As described in [issue #353](https://github.com/benfred/py-spy/issues/353), the installation only works with pip version 20.2.4. I'm also proposing a python alpine base image (aka `python:3.8-alpine`) for compatibility reason
```
- Build error with the current `pip` version
docker build -t italux/kubectl-flame -f agent/docker/python/Dockerfile .
[+] Building 5.0s (14/18)
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                       0.0s
 => => transferring dockerfile: 588B                                                                                                                                                                                                                                       0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                            0.0s
 => [internal] load metadata for docker.io/library/golang:1.14-buster                                                                                                                                                                                                      2.2s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                                                                                                                                           0.0s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                                                                                                                                              0.0s
 => [internal] load build context                                                                                                                                                                                                                                          0.0s
 => => transferring context: 17.37kB                                                                                                                                                                                                                                       0.0s
 => [agentbuild 1/5] FROM docker.io/library/golang:1.14-buster@sha256:d580c337738984ec7e30738d0a97316b0cf26e296572a7d211f4891ca02288bb                                                                                                                                     0.0s
 => [pyspybuild 1/4] FROM docker.io/library/alpine                                                                                                                                                                                                                         0.0s
 => CACHED [pyspybuild 2/4] RUN apk add python3 py3-pip                                                                                                                                                                                                                    0.0s
 => CACHED [pyspybuild 3/4] RUN echo 'manylinux1_compatible = True' > /usr/lib/python3.8/site-packages/_manylinux.py                                                                                                                                                       0.0s
 => ERROR [pyspybuild 4/4] RUN pip3 install py-spy==0.4.0.dev1                                                                                                                                                                                                             2.6s
 => CACHED [agentbuild 2/5] WORKDIR /go/src/github.com/VerizonMedia/kubectl-flame                                                                                                                                                                                          0.0s
 => [agentbuild 3/5] ADD . /go/src/github.com/VerizonMedia/kubectl-flame                                                                                                                                                                                                   0.4s
 => CANCELED [agentbuild 4/5] RUN go get -d -v ./...                                                                                                                                                                                                                       2.3s
------
 > [pyspybuild 4/4] RUN pip3 install py-spy==0.4.0.dev1:
#17 2.191 ERROR: Could not find a version that satisfies the requirement py-spy==0.4.0.dev1
#17 2.191 ERROR: No matching distribution found for py-spy==0.4.0.dev1
------
executor failed running [/bin/sh -c pip3 install py-spy==0.4.0.dev1]: exit code: 1
```
- With the proposed fixes
```
docker build -t italux/kubectl-flame:py-spy-install -f agent/docker/python/Dockerfile
[+] Building 12.4s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                       0.0s
 => => transferring dockerfile: 706B                                                                                                                                                                                                                                       0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                            0.0s
 => [internal] load metadata for docker.io/library/golang:1.14-buster                                                                                                                                                                                                      1.1s
 => [internal] load metadata for docker.io/library/python:3.8-alpine                                                                                                                                                                                                       0.0s
 => [agentbuild 1/5] FROM docker.io/library/golang:1.14-buster@sha256:d580c337738984ec7e30738d0a97316b0cf26e296572a7d211f4891ca02288bb                                                                                                                                     0.0s
 => [internal] load build context                                                                                                                                                                                                                                          0.0s
 => => transferring context: 15.59kB                                                                                                                                                                                                                                       0.0s
 => [pyspybuild 1/4] FROM docker.io/library/python:3.8-alpine                                                                                                                                                                                                              0.0s
 => CACHED [agentbuild 2/5] WORKDIR /go/src/github.com/VerizonMedia/kubectl-flame                                                                                                                                                                                          0.0s
 => [agentbuild 3/5] ADD . /go/src/github.com/VerizonMedia/kubectl-flame                                                                                                                                                                                                   0.2s
 => [agentbuild 4/5] RUN go get -d -v ./...                                                                                                                                                                                                                                8.8s
 => [agentbuild 5/5] RUN cd agent && go build -o /go/bin/agent                                                                                                                                                                                                             2.2s
 => CACHED [stage-2 2/4] RUN mkdir /app                                                                                                                                                                                                                                    0.0s
 => CACHED [stage-2 3/4] COPY --from=agentbuild /go/bin/agent /app/agent                                                                                                                                                                                                   0.0s
 => CACHED [pyspybuild 2/4] RUN pip install pip==20.2.4                                                                                                                                                                                                                    0.0s
 => CACHED [pyspybuild 3/4] RUN echo 'manylinux1_compatible = True' > /usr/local/lib/python3.8/site-packages/_manylinux.py                                                                                                                                                 0.0s
 => CACHED [pyspybuild 4/4] RUN pip3 install py-spy==0.4.0.dev1                                                                                                                                                                                                            0.0s
 => CACHED [stage-2 4/4] COPY --from=pyspybuild /usr/local/bin/py-spy /app/py-spy                                                                                                                                                                                          0.0s
 => exporting to image                                                                                                                                                                                                                                                     0.0s
 => => exporting layers                                                                                                                                                                                                                                                    0.0s
 => => writing image sha256:f1a7687add2af3f9973b56d3e8a3e4f54e04189d86d9e31e35558de85c83ac49                                                                                                                                                                               0.0s
 => => naming to docker.io/italux/kubectl-flame:py-spy-install
```