### PR TITLE
fix: add event arg and validate pgrep

### DIFF
--- a/cli/cmd/kubernetes/job/python.go
+++ b/cli/cmd/kubernetes/job/python.go
@@ -24,7 +24,11 @@ func (p *pythonCreator) create(targetPod *apiv1.Pod, cfg *data.FlameConfig) (str
 		cfg.TargetConfig.ContainerId,
 		cfg.TargetConfig.Duration.String(),
 		string(cfg.TargetConfig.Language),
-		cfg.TargetConfig.Pgrep,
+		string(cfg.TargetConfig.Event),
+	}
+
+	if cfg.TargetConfig.Pgrep != "" {
+		args = append(args, cfg.TargetConfig.Pgrep)
 	}
 
 	if cfg.TargetConfig.Image != "" {


### PR DESCRIPTION
Fixes #38 
Fixes #46

### Description
Even after the changes applied on #42 the reported error still happen and this was due to a missing argument (aka `--event`) and also the validation of the `--pgrep`
```
~# date; go build -v -o kube-flame
Thu Feb 25 15:05:29 -03 2021
github.com/VerizonMedia/kubectl-flame/cli/cmd/kubernetes/job
github.com/VerizonMedia/kubectl-flame/cli/cmd/kubernetes
```
```
~# date ; ./kube-flame -n namespace pod-name -t 1m --lang python -f /tmp/flamegraph.svg container-name --image verizondigital/kubectl-flame:v0.2.0-python -p uwsgi
Thu Feb 25 15:07:14 -03 2021
Verifying target pod ... ✔
Launching profiler ... ✔
Profiling ... ✔
FlameGraph saved to: /tmp/flamegraph.svg 🔥
```