### PR TITLE
Fix jvm alpine profile error

### DIFF
--- a/agent/docker/jvm/Dockerfile.alpine
+++ b/agent/docker/jvm/Dockerfile.alpine
@@ -5,13 +5,17 @@ RUN go get -d -v ./...
 RUN cd agent && go build -o /go/bin/agent
 
 FROM openjdk:8-alpine as asyncprofiler
-RUN apk add build-base git linux-headers
-RUN git clone https://github.com/edeNFed/async-profiler.git
-RUN cd async-profiler && make
+RUN mkdir -p /usr/share/async-profiler/ && \
+    wget -O /usr/share/async-profiler/async-profiler.tar.gz https://github.com/jvm-profiling-tools/async-profiler/releases/download/v1.8.4/async-profiler-1.8.4-linux-musl-x64.tar.gz && \
+    cd /usr/share/async-profiler/ && \
+    tar -xvzf async-profiler.tar.gz && \
+    sed -i 's/^SCRIPT_DIR=.*/SCRIPT_DIR=\"\/tmp\/async-profiler\"/g' /usr/share/async-profiler/async-profiler-1.8.4-linux-musl-x64/profiler.sh
 
-FROM alpine
+FROM openjdk:8-alpine
 RUN mkdir -p /app/async-profiler/build
 COPY --from=agentbuild /go/bin/agent /app
-COPY --from=asyncprofiler /async-profiler/build /app/async-profiler/build
-COPY --from=asyncprofiler /async-profiler/profiler.sh /app/async-profiler
+# COPY --from=asyncprofiler /async-profiler/build /app/async-profiler/build
+# COPY --from=asyncprofiler /async-profiler/profiler.sh /app/async-profiler
+COPY --from=asyncprofiler /usr/share/async-profiler/async-profiler-1.8.4-linux-musl-x64/build /app/async-profiler/build
+COPY --from=asyncprofiler /usr/share/async-profiler/async-profiler-1.8.4-linux-musl-x64/profiler.sh /app/async-profiler
 CMD [ "/app/agent" ]

--- a/agent/docker/jvm/Dockerfile.alpine
+++ b/agent/docker/jvm/Dockerfile.alpine
@@ -12,10 +12,9 @@ RUN mkdir -p /usr/share/async-profiler/ && \
     sed -i 's/^SCRIPT_DIR=.*/SCRIPT_DIR=\"\/tmp\/async-profiler\"/g' /usr/share/async-profiler/async-profiler-1.8.4-linux-musl-x64/profiler.sh
 
 FROM openjdk:8-alpine
-RUN mkdir -p /app/async-profiler/build
+RUN mkdir -p /app/async-profiler/build && \
+    apk add --no-cache libstdc++
 COPY --from=agentbuild /go/bin/agent /app
-# COPY --from=asyncprofiler /async-profiler/build /app/async-profiler/build
-# COPY --from=asyncprofiler /async-profiler/profiler.sh /app/async-profiler
 COPY --from=asyncprofiler /usr/share/async-profiler/async-profiler-1.8.4-linux-musl-x64/build /app/async-profiler/build
 COPY --from=asyncprofiler /usr/share/async-profiler/async-profiler-1.8.4-linux-musl-x64/profiler.sh /app/async-profiler
 CMD [ "/app/agent" ]


### PR DESCRIPTION
Fixes #27

## Description
This attempt to fix the issue profiling alpine images by upgrading the `async-profiler` version as mentioned on [issue #362](https://github.com/jvm-profiling-tools/async-profiler/issues/362#issuecomment-718295671), which recommends using `async-profiler-*-linux-musl-x64` when in alpine image. I'm also making an in-line patch (the same did by @edeNFed [here](https://github.com/jvm-profiling-tools/async-profiler/compare/master...edeNFed:master)) to be able to use the upstream source code.

Besides that, I've realized that the issue happens because the alpine image doesn't have the `libstdc++` when executing the `profiler.sh`, so I'm adding the missing lib on the Dockerfile.
```
# /tmp/async-profiler/profiler.sh -d 60 -f /tmp/flamegraph.svg -e wall 1
Failed to inject profiler into 1
        ldd (0x7f1ebca35000)
Error loading shared library libstdc++.so.6: No such file or directory (needed by /tmp/async-profiler/build/libasyncProfiler.so)
        libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x7f1ebc1e2000)
        libc.musl-x86_64.so.1 => ldd (0x7f1ebca35000)
```

**NOTE**.: This still not fix the issue completely. During my research, even with the new image, I realized that even agent and target containers need to have the `libstdc++` installed. When the target container has the `libstdc++`, everything "works fine":
```
Verifying target pod ... ✔
Launching profiler ... ✔
Profiling ... Got invalid event: invalid character '/' looking for beginning of value
✔
FlameGraph saved to: /tmp/farinha-flamegraph.svg 🔥
```